### PR TITLE
Fixed trace_out

### DIFF
--- a/photon_weave/extra/einsum_constructor.py
+++ b/photon_weave/extra/einsum_constructor.py
@@ -195,7 +195,10 @@ def trace_out_vector(state_objs: list, states: list) -> str:
     return f"{einsum_str[0]}->{einsum_str[1]}"
 
 
-def trace_out_matrix(state_objs: list, states: list) -> str:
+def trace_out_matrix(
+    state_objs: list,
+    states: list
+    ) -> str:
     """
     Produces an Einstein sum string. It's application traces out
     the states which are not included in the states list. Where
@@ -216,11 +219,13 @@ def trace_out_matrix(state_objs: list, states: list) -> str:
 
     einsum_list_list: List[List[int]] = [[], []]
     counter = itertools.count(start=0)
-    sum_out = next(counter)
+    einsum_dict: Dict["BaseState", int] = {}
     for _ in range(2):
         for so in state_objs:
-            if so not in states:
-                einsum_list_list[0].append(sum_out)
+            if not any(so.uid==s.uid for s in states):
+                if so not in einsum_dict.keys():
+                    einsum_dict[so] = next(counter)
+                einsum_list_list[0].append(einsum_dict[so])
             else:
                 c = next(counter)
                 einsum_list_list[0].append(c)

--- a/tests/utils/test_einsum_constructor.py
+++ b/tests/utils/test_einsum_constructor.py
@@ -1,0 +1,15 @@
+import unittest
+
+from photon_weave.state.fock import Fock
+import photon_weave.extra.einsum_constructor as ESC
+
+class TestTraceOut(unittest.TestCase):
+    def test_trace_out_matrix(self) -> None:
+        """
+        Test the correctness of the trace out einsum string generation
+        """
+        fock1 = Fock()
+        fock2 = Fock()
+        fock3 = Fock()
+        einsum = ESC.trace_out_matrix([fock1, fock2, fock3], [fock2])
+        self.assertEqual(einsum, "abcadc->bd")


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes.
      

- [x] The Photon_Weave source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      
When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
There is a bug in the trace_out logic. In einsum_constructor (`trace_out_matrix` assigned the same letter for all traced out systems, which is incorrect. It has to assign a new letter for each state.

**Description of the Change:**
Now the trace out (in einsum_constructor) actually constructs the correct einsum string.
**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
